### PR TITLE
Configure file uploads directory within project resources

### DIFF
--- a/config/config.properties
+++ b/config/config.properties
@@ -1,19 +1,19 @@
 ##########################
-## Configuraci髇 global de la aplicaci髇 RentExpress
+## Configuraci贸n global de la aplicaci贸n RentExpress
 ##########################
 
-# Configuraci髇 de la base de datos
+# Configuraci贸n de la base de datos
 db.url=jdbc:mysql://localhost:3306/rentexpres?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
 db.user=root
 db.password=*/SQL28base
 db.driver=com.mysql.cj.jdbc.Driver
 
-# Configuraci髇 de env韔 de correo
+# Configuraci贸n de env铆o de correo
 mail.email=rentexpressw1@gmail.com
 mail.password=envx hipd mtif nwqp
 mail.smtp.server.name=smtp.gmail.com
 mail.smtp.server.port=587
 
 
-#configuracion de carpetas para imagen
-base.image.path=C:/Users/joliva/Mi unidad/eclipse-workspace/rentexpresIMG
+# Configuraci贸n de carpetas para imagen
+base.image.path=resources/uploads

--- a/service/impl/FileServiceImpl.java
+++ b/service/impl/FileServiceImpl.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.pinguela.rentexpres.config.ConfigManager;
 import com.pinguela.rentexpres.service.FileService;
 
 /**
@@ -25,7 +26,7 @@ import com.pinguela.rentexpres.service.FileService;
 public class FileServiceImpl implements FileService {
 
     private static final Logger LOGGER = LogManager.getLogger(FileServiceImpl.class);
-    private static final Path UPLOAD_DIR = Paths.get(System.getProperty("user.dir"), "uploads");
+    private static final Path UPLOAD_DIR = initializeUploadDir();
     private static final long MAX_FILE_SIZE = 2L * 1024L * 1024L; // 2 MB
     private static final String[] ALLOWED_EXTENSIONS = { "jpg", "jpeg", "png" };
 
@@ -218,5 +219,28 @@ public class FileServiceImpl implements FileService {
             buffer.write(data, 0, bytesRead);
         }
         return buffer.toByteArray();
+    }
+
+    private static Path initializeUploadDir() {
+        String configuredPath = ConfigManager.getValue("base.image.path");
+        Path basePath;
+        if (configuredPath == null || configuredPath.isBlank()) {
+            basePath = Paths.get(System.getProperty("user.dir"), "resources", "uploads");
+        } else {
+            Path configured = Paths.get(configuredPath);
+            if (configured.isAbsolute()) {
+                basePath = configured;
+            } else {
+                basePath = Paths.get(System.getProperty("user.dir"), configuredPath);
+            }
+        }
+
+        try {
+            Files.createDirectories(basePath);
+        } catch (IOException e) {
+            LOGGER.error("No se pudo crear el directorio base de subidas: {}", basePath, e);
+        }
+
+        return basePath.toAbsolutePath().normalize();
     }
 }


### PR DESCRIPTION
## Summary
- load the base image path from configuration in `FileServiceImpl`
- default the upload directory to a resources/uploads folder within the project
- ensure the configuration file points to the new relative path and add the folder to the repo

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da5b77b9cc8331b1d17c0f2688e7e9